### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+config.json
+history.csv
+
 # Git
 .git
 .gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Git
+.git
+.gitignore
+.github
+
+# Docker
+.dockerignore
+Dockerfile
+
+# IDE
+.idea
+.vscode
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.py[cod]
+*$py.class
+.pytest_cache/
+..mypy_cache/
+
+# poetry
+.venv
+
+# C extensions
+*.so
+
+# Virtual environment
+.venv
+venv
+.python-version
+
+.DS_Store
+.AppleDouble
+.LSOverride
+._*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-slim-buster
+
+# Fixes "ImportError: libGL.so.1: cannot open shared object file: No such file or directory"
+RUN apt-get update && apt-get install -y ffmpeg libsm6 libxext6
+
+RUN pip install pipenv
+
+WORKDIR /app
+COPY Pipfile /app
+COPY Pipfile.lock /app
+
+RUN pipenv install --system --deploy
+
+COPY . /app
+
+CMD ./genconf.sh && python app.py --cli

--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ pipenv install
 pipenv run python app.py
 ```
 
+### Docker
+
+Build docker image
+```
+docker build -t overwatch-omnic-rewards .
+```
+
+Run the app inside docker container (Put your ID of your account instead of 123456789)
+```bash
+docker run -d -e ACCOUNT_ID=123456789 overwatch-omnic-rewards
+```
+
 ## Developing
 
 This app uses pipenv to manage its requirements. Install the dev requirements if you want to develop and test the app

--- a/genconf.sh
+++ b/genconf.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [[ -z "${ACCOUNT_ID}" ]]; then
+  echo "ACCOUNT_ID must be set"
+  exit 1
+fi
+
+# Save config file for specified account id
+cat > config.json << EOL
+{
+    "account": "${ACCOUNT_ID}",
+    "owl": true,
+    "owc": true,
+    "middle_click": "open_owl_owc",
+    "left_click": "context_menu",
+    "min_check": 10,
+    "force_track": false
+}
+EOL


### PR DESCRIPTION
I added Dockerfile so that it should be easier to deploy the application on the server using Docker. I didn't modify any source code of the application, however I suggest to do the following in the near future:
- Get rid of required PyQt dependency as there is no GUI in CLI mode. I haven't worked with pipenv but [poetry allows to mark packages as optional](https://python-poetry.org/docs/pyproject/#extras). At the moment, a few dependencies (`ffmpeg libsm6 libxext6`) are required to make the app working properly (because of PyQt5).
- Allow to pass account ID as an environment variable. As a workaround, I created a simple bash script, which generates the config file using the passed environment variable.